### PR TITLE
Added getTemplateSettings and setInterpolationSymbols

### DIFF
--- a/express-dot.js
+++ b/express-dot.js
@@ -2,7 +2,6 @@ var fs = require('fs');
 var path = require('path');
 var doT = require('dot');
 var async = require('async');
-var path = require('path'); 
 
 var _cache = {};
 var _partialsCache = {};
@@ -78,6 +77,30 @@ exports.setTemplateSettings = function(settings) {
 exports.getTemplateSettings = function(settings) {
   return doT.templateSettings;
 };
+
+exports.setInterpolationSymbols = function(startSymbol, endSymbol) {
+  for (option in doT.templateSettings) {
+    var value = doT.templateSettings[option];
+    if (value instanceof RegExp) {
+      var regexStr = value.toString()
+      regexStr = regexStr
+                  .replace(/\\\{\\\{/g, _regexStr(startSymbol))
+                  .replace(/\\\}\\\}/g, _regexStr(endSymbol));
+      doT.templateSettings[option] = _toRegExp(regexStr);
+    }
+  }
+  console.log(doT.templateSettings);
+};
+
+function _regexStr(str) {
+  return str.replace(/([^a-z0-9_])/ig, '\\$1')
+}
+
+var regexpStringPattern = /^\/(.*)\/([gimy]*)$/;
+function _toRegExp(str) {
+    var rx = str.match(regexpStringPattern);
+    if (rx) return new RegExp(rx[1], rx[2]);
+}
 
 exports.__express = function(filename, options, cb) {
   'use strict';

--- a/express-dot.js
+++ b/express-dot.js
@@ -75,6 +75,10 @@ exports.setTemplateSettings = function(settings) {
   }
 };
 
+exports.getTemplateSettings = function(settings) {
+  return doT.templateSettings;
+};
+
 exports.__express = function(filename, options, cb) {
   'use strict';
   cb = (typeof cb === 'function') ? cb : function() {};

--- a/express-dot.js
+++ b/express-dot.js
@@ -123,3 +123,7 @@ exports.__express = function(filename, options, cb) {
     return _renderWithLayout(filename, layoutTemplate, options, cb);
   });
 };
+
+
+exports.template = doT.template;
+exports.compile = doT.compile;

--- a/express-dot.js
+++ b/express-dot.js
@@ -89,7 +89,6 @@ exports.setInterpolationSymbols = function(startSymbol, endSymbol) {
       doT.templateSettings[option] = _toRegExp(regexStr);
     }
   }
-  console.log(doT.templateSettings);
 };
 
 function _regexStr(str) {


### PR DESCRIPTION
While possible to change interpolation symbols {{ and }} by changing template options, it is error-prone.
setInterpolationSymbols changes template settings to use different interpolation settings.
E.g. dot.setInterpolationSymbols('<%', '%>') produces these options:

```
{
    evaluate: /\<\%([\s\S]+?(\}?)+)\%\>/g,
    interpolate: /\<\%=([\s\S]+?)\%\>/g,
    encode: /\<\%!([\s\S]+?)\%\>/g
    // ...
}
```
